### PR TITLE
 Added method to obtain file name, test comment, procedure name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     - [ChannelInterface Configuration](#channelinterface-configuration)
   - [Getting Cycler Level Information](#getting-cycler-level-information)
   - [Getting Channel Readings](#getting-channel-readings)
+  - [Getting File Name, Test Comment, Procedure Name](#getting-file-name-test-comment-procedure-name)
   - [Starting a Test](#starting-a-test)
   - [Setting Variables](#setting-variables)
   - [Direct Control](#direct-control)
@@ -199,6 +200,52 @@ Example output:
 
 ```text
 {'FClass': 4, 'FNum': 7, 'Chan': 1, 'RF1': 0, 'RF2': 192, 'Stat': 0, 'LastRecNum': 4225, 'Cycle': 0, 'Step': 5, 'TestTime': 2.0, 'StepTime': 1.0, 'Capacity': 0, 'Energy': 0, 'Current': 0, 'Voltage': 3.85, 'TesterTime': '2022-10-13T12:32:56'}
+```
+
+
+### Getting File Name, Test Comment, Procedure Name
+
+Below is example code for reading read data file name, test comment, procedure name and procedure description from channel 75.
+
+```python
+import time
+import sys
+import pymacnet 
+
+config = {
+    "server_ip": "127.0.0.1",
+    "json_msg_port": 57570,
+    "bin_msg_port": 57560,
+    "msg_buffer_size_bytes": 1024
+    "channel": 75,
+    "test_name": "",
+    "c_rate_ah": 1,
+    "v_max_v": 4.2,
+    "v_min_v": 3.0,
+    "v_max_safety_limit_v": 4.25,
+    "v_min_safety_limit_v": 2.9,
+    "i_max_safety_limit_a": 3.0,
+    "i_min_safety_limit_a": 3.0,
+    "power_safety_limit_chg_w": 25,
+    "power_safety_limit_dsg_w": 25,
+    "data_record_time_s": 0.05,
+    "data_record_voltage_delta_vbys": 0.0,
+    "data_record_current_delta_abys": 0.0,
+    "test_procedure": "test_procedure_1",
+}
+    
+channel_interface = pymacnet.ChannelInterface(config)
+if not channel_interface.start():
+    sys.exit("failed to create connection!")
+
+status_reading = channel_interface.read_channel_test_names()
+print(status_reading)
+```
+
+Example output:
+
+```text
+{"FClass":4, "FNum":6, "Chan":3, "TestName":"Arbitrary file name 2016-11-10 10-07-05_126", "ProcName":"Send email"}
 ```
 
 ### Starting a Test

--- a/pymacnet/channel_interface.py
+++ b/pymacnet/channel_interface.py
@@ -59,6 +59,17 @@ class ChannelInterface(CyclerInterface):
         '''
         return self.__channel
 
+    def read_channel_test_names(self) -> dict:
+        """
+        Method to read data file name, test comment, procedure name and procedure description.
+
+        Returns
+        -------
+        status : dict
+            A dictionary detailing the status of the channel. Returns None if there is an issue.
+        """
+        return super().read_channel_test_names(channel=(self.__channel))
+    
     def read_channel_status(self) -> dict:
         """
         Method to read the status of the channel defined in the config.

--- a/pymacnet/channel_interface.py
+++ b/pymacnet/channel_interface.py
@@ -65,8 +65,8 @@ class ChannelInterface(CyclerInterface):
 
         Returns
         -------
-        status : dict
-            A dictionary detailing the status of the channel. Returns None if there is an issue.
+        names : dict
+            A dictionary detailing file name, test comment, procedure name and procedure description of the channel. Returns None if there is an issue.
         """
         return super().read_channel_test_names(channel=(self.__channel))
     

--- a/pymacnet/cycler_interface.py
+++ b/pymacnet/cycler_interface.py
@@ -79,6 +79,37 @@ class CyclerInterface():
             logger.error("Failed to read system info!")
             return None
 
+    def read_channel_test_names(self, channel: int) -> dict:
+        """
+        Method to read data file name, test comment, procedure name and procedure description for the specified `channel`.
+
+        Returns
+        -------
+        names : dict
+            A dictionary detailing file name, test comment, procedure name and procedure description of the channel. Returns None if there is an issue.
+        """
+        names = {}
+
+        if not (channel > 0) and not (channel < self.__num_channels):
+            logger.warning("Invalid channel number!")
+            return None
+
+        try:
+            msg_outgoing_dict = copy.deepcopy(
+                pymacnet.messages.rx_read_names)
+            msg_outgoing_dict['params']['Chan'] = channel
+            names = self._send_receive_json_msg(msg_outgoing_dict)
+        except Exception as e:
+            logger.error(
+                f'Error reading file name, test comment, procedure name and procedure description for channel {channel}', exc_info=True)
+            logger.error(e)
+
+        if names and 'result' in names:
+            return names['result']
+        else:
+            logger.error("Failed to read channel file name, test comment, procedure name and procedure description")
+            return None
+    
     def read_channel_status(self, channel: int) -> dict:
         """
         Reads channel status for the specified `channel`.

--- a/pymacnet/messages/messages.py
+++ b/pymacnet/messages/messages.py
@@ -12,7 +12,20 @@ tx_read_status_msg = {
 """
 Gets the status and readings of one channel. The status and readings of `Chan` channel will be returned.
 """
-
+rx_read_names = {
+    'jsonrpc': '2.0',
+    'method': 'MacNet',
+    'params':
+    {
+        'FClass': 4,
+        'FNum': 6,
+        'Chan': -1
+    },
+    'id': 1987
+}
+"""
+The data file name, test comment, procedure name and procedure description of “Chan” channel will be returned.
+"""
 rx_read_status_msg = {
     'jsonrpc': '2.0',
     'result':


### PR DESCRIPTION
Added rx_read_names in messages.py and read_channel_test_names functions in channel_interface.py and cycler_interface.py. Added example in Readme.
Based on this

rx_read_names = {
    'jsonrpc': '2.0',
    'method': 'MacNet',
    'params':
    {
        **'FClass': 4,
        'FNum': 6,**
        'Chan': -1
    },
    'id': 1987
}